### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -6,7 +6,7 @@ The documentation in this section is intended for developers and operators inter
 
 ### Understand Routing Components and Concepts
 
-* [Gorouter](../concepts/architecture/router.html)
+* [<%= vars.app_runtime_abbr %> Routing Architecture](../concepts/cf-routing-architecture.html)
 
 * [HTTP Routing](../concepts/http-routing.html)
 
@@ -15,8 +15,6 @@ The documentation in this section is intended for developers and operators inter
 <%= vars.tls_info_subnav %>
 
 <%= vars.vsphere_az_subnav %>
-
-* [<%= vars.app_runtime_abbr %> Routing Architecture](../concepts/cf-routing-architecture.html)
 
 ### Manage and Troubleshoot Routing
 


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106